### PR TITLE
no more keepalives

### DIFF
--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -74,7 +74,7 @@ defmodule ExTwilio.Api do
 
     module
     |> Url.build_url(nil, url_options)
-    |> Api.post!(data, auth_header(options))
+    |> Api.post!(data, auth_header(options), keepalive: false)
     |> Parser.parse(module)
   end
 


### PR DESCRIPTION
this appears to massively improve the 95th percentile Twilio API response times on outbound messages and has a noticeable positive impact on the mean